### PR TITLE
Always installs latest version of code server

### DIFF
--- a/colabcode/code.py
+++ b/colabcode/code.py
@@ -48,7 +48,8 @@ class ColabCode:
     def _install_code():
         subprocess.run(["wget", "https://code-server.dev/install.sh"], stdout=subprocess.PIPE)
         subprocess.run(
-            ["sh", "install.sh", "--version", f"{CODESERVER_VERSION}"],
+            # ["sh", "install.sh", "--version", f"{CODESERVER_VERSION}"],
+            ["sh", "install.sh"],
             stdout=subprocess.PIPE,
         )
 


### PR DESCRIPTION
Removes hardcoded vscode version `CODESERVER_VERSION`. Thus, it always installs latest version of code server. With hard coded version, I was unable to install the extensions from the vscode extensions marketplace. Also it seems that ngrok now requires users to create authtoken. So, this version might need users to provide their authtoken:

```
ColabCode(port=80, password="<enter-password>", mount_drive=True, authtoken='<enter-your-ngrok-auth-token>`)
```

Sample [colab notebook to boot up with colabcode](https://colab.research.google.com/drive/1Yu_ctumurM5ApvVp882GfWst5G3RoSLI?usp=sharing).